### PR TITLE
Revert "chore(deps): bump slf4jVersion from 1.7.36 to 2.0.7"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ ext {
 
     amazonS3Version = "1.12.500"
     amazonSTSVersion = "1.12.479"
-    slf4jVersion = "2.0.7"
+    slf4jVersion = "1.7.36"
     junitVersion = "5.10.0"
     testcontainersVersion = "1.18.3"
     localstackVersion = "0.2.23"


### PR DESCRIPTION
This reverts commit b5d06f67

See https://github.com/Aiven-Open/opensearch-connector-for-apache-kafka/pull/219#issuecomment-1651850483