### PR TITLE
Add Support for setting SSEA name

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,13 @@ There are four configuration properties to configure retry strategy exists.
   integer overflow issues during delay calculation).
   Default is `3`.
 
+### AWS S3 server side encryption properties
+
+- `aws.s3.ssea.name` - The name of the Server-side encryption algorithm to use for uploads. If unset the default SSE-S3 is used.
+- To use SSE-S3 set to `AES256`
+- To use SSE-KMS set to `aws:kms`
+- To use DSSE-KMS set to `aws:kms:dsse`
+
 ## Development
 
 ### Developing together with Commons library

--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ There are four configuration properties to configure retry strategy exists.
 ### AWS S3 server side encryption properties
 
 - `aws.s3.sse.algorithm` - The name of the Server-side encryption algorithm to use for uploads. If unset the default SSE-S3 is used.
-- To use SSE-S3 set to `AES256`
+- To use SSE-S3 set to `AES256` or leave empty
 - To use SSE-KMS set to `aws:kms`
 - To use DSSE-KMS set to `aws:kms:dsse`
 

--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ There are four configuration properties to configure retry strategy exists.
 
 ### AWS S3 server side encryption properties
 
-- `aws.s3.ssea.name` - The name of the Server-side encryption algorithm to use for uploads. If unset the default SSE-S3 is used.
+- `aws.s3.sse.algorithm` - The name of the Server-side encryption algorithm to use for uploads. If unset the default SSE-S3 is used.
 - To use SSE-S3 set to `AES256`
 - To use SSE-KMS set to `aws:kms`
 - To use DSSE-KMS set to `aws:kms:dsse`

--- a/src/main/java/io/aiven/kafka/connect/s3/S3OutputStream.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3OutputStream.java
@@ -29,9 +29,9 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,8 +68,7 @@ public class S3OutputStream extends OutputStream {
                           final String key,
                           final int partSize,
                           final AmazonS3 client,
-                          final String serverSideEncryptionAlgorithm
-                      ) {
+                          final String serverSideEncryptionAlgorithm) {
         this.bucketName = bucketName;
         this.key = key;
         this.client = client;

--- a/src/main/java/io/aiven/kafka/connect/s3/S3OutputStream.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3OutputStream.java
@@ -31,6 +31,7 @@ import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,17 +53,29 @@ public class S3OutputStream extends OutputStream {
 
     private final int partSize;
 
+    private final String serverSideEncryptionAlgorithm;
+
     private boolean closed = false;
 
     public S3OutputStream(final String bucketName,
                           final String key,
                           final int partSize,
                           final AmazonS3 client) {
+        this(bucketName, key, partSize, client, null);
+    }
+
+    public S3OutputStream(final String bucketName,
+                          final String key,
+                          final int partSize,
+                          final AmazonS3 client,
+                          final String serverSideEncryptionAlgorithm
+                      ) {
         this.bucketName = bucketName;
         this.key = key;
         this.client = client;
         this.partSize = partSize;
         this.byteBuffer = ByteBuffer.allocate(partSize);
+        this.serverSideEncryptionAlgorithm = serverSideEncryptionAlgorithm;
     }
 
     @Override
@@ -93,9 +106,20 @@ public class S3OutputStream extends OutputStream {
     private MultipartUpload newMultipartUpload() throws IOException {
         logger.debug("Create new multipart upload request");
         final var initialRequest = new InitiateMultipartUploadRequest(bucketName, key);
+        initialRequest.setObjectMetadata(this.buildObjectMetadata());
         final var initiateResult = client.initiateMultipartUpload(initialRequest);
         logger.debug("Upload ID: {}", initiateResult.getUploadId());
         return new MultipartUpload(initiateResult.getUploadId());
+    }
+
+    private ObjectMetadata buildObjectMetadata() {
+        final ObjectMetadata metadata = new ObjectMetadata();
+
+        if (this.serverSideEncryptionAlgorithm != null) {
+            metadata.setSSEAlgorithm(this.serverSideEncryptionAlgorithm);
+        }
+
+        return metadata;
     }
 
     @Override

--- a/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
@@ -162,7 +162,8 @@ public class S3SinkTask extends SinkTask {
         final var fullKey = config.usesFileNameTemplate() ? filename : oldFullKey(record);
         return new S3OutputStream(
             config.getAwsS3BucketName(),
-            fullKey, config.getAwsS3PartSize(),
+            fullKey,
+            config.getAwsS3PartSize(),
             s3Client,
             config.getServerSideEncryptionAlgorithmName()
         );

--- a/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/S3SinkTask.java
@@ -160,7 +160,12 @@ public class S3SinkTask extends SinkTask {
 
     private OutputStream newStreamFor(final String filename, final SinkRecord record) {
         final var fullKey = config.usesFileNameTemplate() ? filename : oldFullKey(record);
-        return new S3OutputStream(config.getAwsS3BucketName(), fullKey, config.getAwsS3PartSize(), s3Client);
+        return new S3OutputStream(
+            config.getAwsS3BucketName(),
+            fullKey, config.getAwsS3PartSize(),
+            s3Client,
+            config.getServerSideEncryptionAlgorithmName()
+        );
     }
 
     private EndpointConfiguration newEndpointConfiguration(final S3SinkConfig config) {

--- a/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
@@ -235,11 +235,12 @@ public class S3SinkConfig extends AivenCommonConfig {
             null,
             new ConfigDef.NonEmptyString(),
             Importance.MEDIUM,
-            "AWS S3 Server Side Encryption Algorithm",
+            "AWS S3 Server Side Encryption Algorithm. Example values: 'AES256', 'aws:kms'.",
             GROUP_AWS,
             awsGroupCounter++,
             ConfigDef.Width.NONE,
-            AWS_S3_SSEA_NAME_CONFIG
+            AWS_S3_SSEA_NAME_CONFIG,
+            "Example: 'AES256' for S3-managed keys, 'aws:kms' for AWS KMS-managed keys."
         );
 
         configDef.define(

--- a/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
@@ -99,7 +99,7 @@ public class S3SinkConfig extends AivenCommonConfig {
     public static final String AWS_ACCESS_KEY_ID_CONFIG = "aws.access.key.id";
     public static final String AWS_SECRET_ACCESS_KEY_CONFIG = "aws.secret.access.key";
     public static final String AWS_S3_BUCKET_NAME_CONFIG = "aws.s3.bucket.name";
-    public static final String AWS_S3_SSEA_NAME_CONFIG = "aws.s3.ssea.name";
+    public static final String AWS_S3_SSE_ALGORITHM_CONFIG = "aws.s3.sse.algorithm";
     public static final String AWS_S3_ENDPOINT_CONFIG = "aws.s3.endpoint";
     public static final String AWS_S3_REGION_CONFIG = "aws.s3.region";
     public static final String AWS_S3_PART_SIZE = "aws.s3.part.size.bytes";
@@ -230,7 +230,7 @@ public class S3SinkConfig extends AivenCommonConfig {
         );
 
         configDef.define(
-            AWS_S3_SSEA_NAME_CONFIG,
+            AWS_S3_SSE_ALGORITHM_CONFIG,
             Type.STRING,
             null,
             new ConfigDef.NonEmptyString(),
@@ -239,7 +239,7 @@ public class S3SinkConfig extends AivenCommonConfig {
             GROUP_AWS,
             awsGroupCounter++,
             ConfigDef.Width.NONE,
-            AWS_S3_SSEA_NAME_CONFIG,
+            AWS_S3_SSE_ALGORITHM_CONFIG,
             "Example: 'AES256' for S3-managed keys, 'aws:kms' for AWS KMS-managed keys."
         );
 
@@ -797,7 +797,7 @@ public class S3SinkConfig extends AivenCommonConfig {
     }
 
     public String getServerSideEncryptionAlgorithmName() {
-        return getString(AWS_S3_SSEA_NAME_CONFIG);
+        return getString(AWS_S3_SSE_ALGORITHM_CONFIG);
     }
 
     public String getAwsS3Prefix() {

--- a/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
@@ -229,6 +229,8 @@ public class S3SinkConfig extends AivenCommonConfig {
             AWS_S3_BUCKET_NAME_CONFIG
         );
 
+        // AWS S3 Server Side Encryption Algorithm configuration
+        // Example values: 'AES256' for S3-managed keys, 'aws:kms' for AWS KMS-managed keys
         configDef.define(
             AWS_S3_SSE_ALGORITHM_CONFIG,
             Type.STRING,
@@ -239,8 +241,7 @@ public class S3SinkConfig extends AivenCommonConfig {
             GROUP_AWS,
             awsGroupCounter++,
             ConfigDef.Width.NONE,
-            AWS_S3_SSE_ALGORITHM_CONFIG,
-            "Example: 'AES256' for S3-managed keys, 'aws:kms' for AWS KMS-managed keys."
+            AWS_S3_SSE_ALGORITHM_CONFIG
         );
 
         configDef.define(

--- a/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/S3SinkConfig.java
@@ -99,6 +99,7 @@ public class S3SinkConfig extends AivenCommonConfig {
     public static final String AWS_ACCESS_KEY_ID_CONFIG = "aws.access.key.id";
     public static final String AWS_SECRET_ACCESS_KEY_CONFIG = "aws.secret.access.key";
     public static final String AWS_S3_BUCKET_NAME_CONFIG = "aws.s3.bucket.name";
+    public static final String AWS_S3_SSEA_NAME_CONFIG = "aws.s3.ssea.name";
     public static final String AWS_S3_ENDPOINT_CONFIG = "aws.s3.endpoint";
     public static final String AWS_S3_REGION_CONFIG = "aws.s3.region";
     public static final String AWS_S3_PART_SIZE = "aws.s3.part.size.bytes";
@@ -226,6 +227,19 @@ public class S3SinkConfig extends AivenCommonConfig {
             awsGroupCounter++,
             ConfigDef.Width.NONE,
             AWS_S3_BUCKET_NAME_CONFIG
+        );
+
+        configDef.define(
+            AWS_S3_SSEA_NAME_CONFIG,
+            Type.STRING,
+            null,
+            new ConfigDef.NonEmptyString(),
+            Importance.MEDIUM,
+            "AWS S3 Server Side Encryption Algorithm",
+            GROUP_AWS,
+            awsGroupCounter++,
+            ConfigDef.Width.NONE,
+            AWS_S3_SSEA_NAME_CONFIG
         );
 
         configDef.define(
@@ -779,6 +793,10 @@ public class S3SinkConfig extends AivenCommonConfig {
         return Objects.nonNull(getString(AWS_S3_BUCKET_NAME_CONFIG))
             ? getString(AWS_S3_BUCKET_NAME_CONFIG)
             : getString(AWS_S3_BUCKET);
+    }
+
+    public String getServerSideEncryptionAlgorithmName() {
+        return getString(AWS_S3_SSEA_NAME_CONFIG);
     }
 
     public String getAwsS3Prefix() {

--- a/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
@@ -32,6 +32,7 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -56,6 +57,8 @@ class S3OutputStreamTest {
     static final String FILE_KEY = "some_key";
 
     static final String UPLOAD_ID = "some_upload_id";
+
+    static final String SSEA_NAME = "AES256";
 
     @Mock
     AmazonS3 mockedAmazonS3;
@@ -108,6 +111,7 @@ class S3OutputStreamTest {
 
         assertThat(initiateMultipartUploadRequest.getBucketName()).isEqualTo(BUCKET_NAME);
         assertThat(initiateMultipartUploadRequest.getKey()).isEqualTo(FILE_KEY);
+        assertThat(initiateMultipartUploadRequest.getObjectMetadata().getContentLength()).isEqualTo(0);
 
         assertCompleteMultipartUploadRequest(
             completeMultipartUploadRequestCaptor.getValue(),
@@ -135,6 +139,26 @@ class S3OutputStreamTest {
         verify(mockedAmazonS3).abortMultipartUpload(abortMultipartUploadRequestCaptor.capture());
 
         assertAbortMultipartUploadRequest(abortMultipartUploadRequestCaptor.getValue());
+    }
+
+    @Test
+    void sendsServerSideEncryptionAlgorithmNameWhenPassed() throws Exception {
+        when(mockedAmazonS3.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+                .thenReturn(newInitiateMultipartUploadResult());
+        when(mockedAmazonS3.uploadPart(any(UploadPartRequest.class)))
+                .thenReturn(newUploadPartResult(1, "SOME_ETAG"));
+        when(mockedAmazonS3.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+                .thenReturn(new CompleteMultipartUploadResult());
+
+        try (final var out = new S3OutputStream(BUCKET_NAME, FILE_KEY, 100, mockedAmazonS3, SSEA_NAME)) {
+            out.write(1);
+        }
+
+        verify(mockedAmazonS3).initiateMultipartUpload(initiateMultipartUploadRequestCaptor.capture());
+
+        final var initiateMultipartUploadRequest = initiateMultipartUploadRequestCaptor.getValue();
+
+        assertEquals(SSEA_NAME, initiateMultipartUploadRequest.getObjectMetadata().getSSEAlgorithm());
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
@@ -157,7 +157,7 @@ class S3OutputStreamTest {
 
         final var initiateMultipartUploadRequest = initiateMultipartUploadRequestCaptor.getValue();
 
-        assertThat(SSEA_NAME).isEqualTo(initiateMultipartUploadRequest.getObjectMetadata().getSSEAlgorithm());
+        assertThat(initiateMultipartUploadRequest.getObjectMetadata().getSSEAlgorithm()).isEqualTo(SSEA_NAME);
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
@@ -158,7 +158,7 @@ class S3OutputStreamTest {
 
         final var initiateMultipartUploadRequest = initiateMultipartUploadRequestCaptor.getValue();
 
-        assertEquals(SSEA_NAME, initiateMultipartUploadRequest.getObjectMetadata().getSSEAlgorithm());
+        assertThat(SSEA_NAME).isEqualTo(initiateMultipartUploadRequest.getObjectMetadata().getSSEAlgorithm());
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
@@ -32,7 +32,6 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/S3OutputStreamTest.java
@@ -110,7 +110,7 @@ class S3OutputStreamTest {
 
         assertThat(initiateMultipartUploadRequest.getBucketName()).isEqualTo(BUCKET_NAME);
         assertThat(initiateMultipartUploadRequest.getKey()).isEqualTo(FILE_KEY);
-        assertThat(initiateMultipartUploadRequest.getObjectMetadata().getContentLength()).isEqualTo(0);
+        assertThat(initiateMultipartUploadRequest.getObjectMetadata().getContentLength()).isZero();
 
         assertCompleteMultipartUploadRequest(
             completeMultipartUploadRequestCaptor.getValue(),


### PR DESCRIPTION
This change adds support for S3 buckets enforcing Server Side Encryption.
- The feature is enabled if the config String `aws.s3.ssea.name` is set
  - valid values are `AES256` and `aws:kms` but this not enforced in the AWS SDK


