### PR TITLE
Fixed log message to say "start" when starting

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkConnector.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/AivenKafkaConnectS3SinkConnector.java
@@ -65,7 +65,7 @@ public class AivenKafkaConnectS3SinkConnector extends SinkConnector {
     public void start(final Map<String, String> properties) {
         Objects.requireNonNull(properties, "properties haven't been set");
         configProperties = Map.copyOf(properties);
-        LOGGER.info("Stop S3 connector");
+        LOGGER.info("Start S3 connector");
     }
 
     @Override


### PR DESCRIPTION
The log message in the connector's start method said "Stop S3 connector", which I assumed is a typo and changed to say "Start S3 connector".