### PR TITLE
chore: bump commons to 0.12

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @aiven/team-helpful-husky @aiven/aiven-open-source
+*   @aiven-open/team-helpful-husky @aiven-open/aiven-open-source

--- a/README.md
+++ b/README.md
@@ -619,9 +619,9 @@ There are four configuration properties to configure retry strategy exists.
 
 ### Developing together with Commons library
 
-This project depends on [Common Module for Apache Kafka Connect](https://github.com/aiven/commons-for-apache-kafka-connect). Normally, an artifact of it published to a globally accessible repository is used. However, if you need to introduce changes to both this connector and Commons library at the same time, you should short-circuit the development loop via locally published artifacts. Please follow this steps:
+This project depends on [Common Module for Apache Kafka Connect](https://github.com/aiven-open/commons-for-apache-kafka-connect). Normally, an artifact of it published to a globally accessible repository is used. However, if you need to introduce changes to both this connector and Commons library at the same time, you should short-circuit the development loop via locally published artifacts. Please follow this steps:
 1. Checkout the `main` `HEAD` of Commons.
-2. Ensure the version [here](https://github.com/aiven/commons-for-apache-kafka-connect/blob/main/gradle.properties) is with `-SNAPSHOT` prefix.
+2. Ensure the version [here](https://github.com/aiven-open/commons-for-apache-kafka-connect/blob/main/gradle.properties) is with `-SNAPSHOT` prefix.
 3. Make changes to Commons.
 4. Publish it locally with `./gradlew publishToMavenLocal`.
 5. Change the version in the connector's [`build.gradle`](build.gradle) (`ext.aivenConnectCommonsVersion`) to match the published snapshot version of Commons.

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ ext {
     confluentPlatformVersion = "4.1.4"
     // Align with version used by commons
     avroConverterVersion = "7.2.2"
-    aivenConnectCommonsVersion = "0.11.0"
+    aivenConnectCommonsVersion = "0.12.0"
 
     amazonS3Version = "1.12.542"
     amazonSTSVersion = "1.12.560"

--- a/build.gradle
+++ b/build.gradle
@@ -279,7 +279,7 @@ publishing {
             pom {
                 name = "Aiven's S3 Sink Connector for Apache Kafka"
                 description = "Aiven's S3 Sink Connector for Apache Kafka"
-                url = "https://github.com/aiven/s3-connector-for-apache-kafka"
+                url = "https://github.com/aiven-open/s3-connector-for-apache-kafka"
                 organization {
                     name = "Aiven Oy"
                     url = "https://aiven.io"
@@ -304,7 +304,7 @@ publishing {
                 scm {
                     connection = 'scm:git:git://github.com:aiven/s3-connector-for-apache-kafka.git'
                     developerConnection = 'scm:git:ssh://github.com:aiven/s3-connector-for-apache-kafka.git'
-                    url = 'https://github.com/aiven/s3-connector-for-apache-kafka'
+                    url = 'https://github.com/aiven-open/s3-connector-for-apache-kafka'
                 }
             }
         }


### PR DESCRIPTION
0.12: https://github.com/Aiven-Open/commons-for-apache-kafka-connect/releases/tag/v0.12.0

See commits for details.