### PR TITLE
Use default or custom provider chain for s3 authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,13 @@ There are two ways to specify AWS credentials in this connector:
 
    The connector will request a temporary token from the AWS STS service and assume a role from another AWS account.
    It requires `aws.sts.role.arn`, `aws.sts.role.session.name` to be specified.
+3) Use default provider chain or custom provider
+   
+    If you prefer to use AWS default provider chain, you can leave {`aws.access.key.id` and `aws.secret.access.key`} and
+    {`aws.sts.role.arn`, `aws.sts.role.session.name`} blank. In case you prefer to build your own custom
+    provider, pass the custom provider class as a parameter to `aws.credential.provider`
 
-It is important not to use both.
+It is important not to use both 1 and 2 simultaneously.
 Using option 2, it is recommended to specify the S3 bucket region in `aws.s3.region` and the
 corresponding AWS STS endpoint in `aws.sts.config.endpoint`. It's better to specify both or none.
 It is also important to specify `aws.sts.role.external.id` for the security reason.

--- a/src/main/java/io/aiven/kafka/connect/s3/config/AwsCredentialProviderFactory.java
+++ b/src/main/java/io/aiven/kafka/connect/s3/config/AwsCredentialProviderFactory.java
@@ -29,7 +29,16 @@ public class AwsCredentialProviderFactory {
         if (config.hasAwsStsRole()) {
             return getStsProvider(config);
         }
-        return getBasicAwsCredentialsProvider(config);
+        final AwsAccessSecret awsCredentials = config.getAwsCredentials();
+        if (!awsCredentials.isValid()) {
+            return config.getCustomCredentialsProvider();
+        }
+        return new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(
+                        awsCredentials.getAccessKeyId().value(),
+                        awsCredentials.getSecretAccessKey().value()
+                )
+        );
     }
 
     private AWSCredentialsProvider getStsProvider(final S3SinkConfig config) {
@@ -55,15 +64,4 @@ public class AwsCredentialProviderFactory {
         }
         return AWSSecurityTokenServiceClientBuilder.defaultClient();
     }
-
-    private AWSCredentialsProvider getBasicAwsCredentialsProvider(final S3SinkConfig config) {
-        final AwsAccessSecret awsCredentials = config.getAwsCredentials();
-        return new AWSStaticCredentialsProvider(
-                new BasicAWSCredentials(
-                        awsCredentials.getAccessKeyId().value(),
-                        awsCredentials.getSecretAccessKey().value()
-                )
-        );
-    }
-
 }

--- a/src/test/java/io/aiven/kafka/connect/s3/AwsCredentialProviderFactoryTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/AwsCredentialProviderFactoryTest.java
@@ -22,6 +22,7 @@ import io.aiven.kafka.connect.s3.config.AwsCredentialProviderFactory;
 import io.aiven.kafka.connect.s3.config.S3SinkConfig;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.regions.Regions;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,5 +67,13 @@ public class AwsCredentialProviderFactoryTest {
 
         final var credentialProvider = factory.getProvider(config);
         assertThat(credentialProvider).isInstanceOf(AWSStaticCredentialsProvider.class);
+    }
+
+    @Test
+    void createDefaultCredentialsWhenNoCredentialsSpecified() {
+        final var config = new S3SinkConfig(props);
+
+        final var credentialProvider = factory.getProvider(config);
+        assertThat(credentialProvider).isInstanceOf(DefaultAWSCredentialsProviderChain.class);
     }
 }

--- a/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkConfigTest.java
@@ -207,37 +207,6 @@ class S3SinkConfigTest {
     }
 
     @Test
-    final void emptyAwsAccessKeyID() {
-        final Map<String, String> props = new HashMap<>();
-        props.put(AWS_ACCESS_KEY_ID, "");
-        assertThatThrownBy(() -> new S3SinkConfig(props))
-            .isInstanceOf(ConfigException.class)
-            .hasMessage("Invalid value [hidden] for configuration aws_access_key_id: Password must be non-empty");
-
-        props.put(S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG, "");
-        assertThatThrownBy(() -> new S3SinkConfig(props))
-            .isInstanceOf(ConfigException.class)
-            .hasMessage("Invalid value [hidden] for configuration aws.access.key.id: Password must be non-empty");
-    }
-
-    @Test
-    final void emptyAwsSecretAccessKey() {
-        final Map<String, String> props = new HashMap<>();
-        props.put(AWS_ACCESS_KEY_ID, "blah-blah-blah");
-        props.put(AWS_SECRET_ACCESS_KEY, "");
-
-        assertThatThrownBy(() -> new S3SinkConfig(props))
-            .isInstanceOf(ConfigException.class)
-            .hasMessage("Invalid value [hidden] for configuration aws_secret_access_key: Password must be non-empty");
-
-        props.put(S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG, "blah-blah-blah");
-        props.put(S3SinkConfig.AWS_SECRET_ACCESS_KEY_CONFIG, "");
-        assertThatThrownBy(() -> new S3SinkConfig(props))
-            .isInstanceOf(ConfigException.class)
-            .hasMessage("Invalid value [hidden] for configuration aws.secret.access.key: Password must be non-empty");
-    }
-
-    @Test
     void wrongPartSize() {
         final var wrongMaxPartSizeProps =
             Map.of(
@@ -730,39 +699,6 @@ class S3SinkConfigTest {
         assertThat(conf.getStsRole().getExternalId()).isEqualTo("EXTERNAL_ID");
         assertThat(conf.getStsRole().getSessionName()).isEqualTo("SESSION_NAME");
         assertThat(conf.getAwsS3Region()).isEqualTo(Regions.US_EAST_1);
-    }
-
-    @Test
-    void stsRoleEmptyArn() {
-        final var props = new HashMap<String, String>();
-
-        props.put(S3SinkConfig.AWS_STS_ROLE_EXTERNAL_ID, "EXTERNAL_ID");
-        props.put(S3SinkConfig.AWS_STS_ROLE_SESSION_NAME, "SESSION_NAME");
-        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "the-bucket");
-        props.put(S3SinkConfig.AWS_S3_REGION_CONFIG, Regions.US_EAST_1.getName());
-
-        assertThatThrownBy(() -> new S3SinkConfig(props))
-            .isInstanceOf(ConfigException.class)
-            .hasMessage(
-                "Either {aws.access.key.id, aws.secret.access.key} or"
-                    + " {aws.sts.role.arn, aws.sts.role.session.name} should be set");
-    }
-
-    @Test
-    void stsRoleEmptySessionName() {
-        final var props = new HashMap<String, String>();
-
-        props.put(S3SinkConfig.AWS_STS_ROLE_ARN, "arn:aws:iam::12345678910:role/S3SinkTask");
-        props.put(S3SinkConfig.AWS_STS_ROLE_EXTERNAL_ID, "EXTERNAL_ID");
-        props.put(S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG, "the-bucket");
-        props.put(S3SinkConfig.AWS_S3_REGION_CONFIG, Regions.US_EAST_1.getName());
-
-        assertThatThrownBy(() -> new S3SinkConfig(props))
-            .isInstanceOf(ConfigException.class)
-            .hasMessage(
-                "Either {aws.access.key.id, aws.secret.access.key} or"
-                    + " {aws.sts.role.arn, aws.sts.role.session.name} should be set"
-            );
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkCredentialsConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/s3/config/S3SinkCredentialsConfigTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.s3.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import org.junit.jupiter.api.Test;
+
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_ACCESS_KEY_ID;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_S3_BUCKET_NAME_CONFIG;
+import static io.aiven.kafka.connect.s3.config.S3SinkConfig.AWS_SECRET_ACCESS_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class S3SinkCredentialsConfigTest {
+    @Test
+    final void emptyAwsAccessKeyID() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(AWS_ACCESS_KEY_ID, "");
+        assertThatThrownBy(() -> new S3SinkConfig(props))
+            .isInstanceOf(ConfigException.class)
+            .hasMessage("Invalid value [hidden] for configuration aws_access_key_id: Password must be non-empty");
+
+        props.put(S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG, "");
+        assertThatThrownBy(() -> new S3SinkConfig(props))
+            .isInstanceOf(ConfigException.class)
+            .hasMessage("Invalid value [hidden] for configuration aws.access.key.id: Password must be non-empty");
+    }
+
+    @Test
+    final void emptyAwsSecretAccessKey() {
+        final Map<String, String> props = new HashMap<>();
+        props.put(AWS_ACCESS_KEY_ID, "blah-blah-blah");
+        props.put(AWS_SECRET_ACCESS_KEY, "");
+
+        assertThatThrownBy(() -> new S3SinkConfig(props))
+            .isInstanceOf(ConfigException.class)
+            .hasMessage("Invalid value [hidden] for configuration aws_secret_access_key: Password must be non-empty");
+
+        props.put(S3SinkConfig.AWS_ACCESS_KEY_ID_CONFIG, "blah-blah-blah");
+        props.put(S3SinkConfig.AWS_SECRET_ACCESS_KEY_CONFIG, "");
+        assertThatThrownBy(() -> new S3SinkConfig(props))
+            .isInstanceOf(ConfigException.class)
+            .hasMessage("Invalid value [hidden] for configuration aws.secret.access.key: Password must be non-empty");
+    }
+
+    /**
+     * Even when no sts role or session name is provided we should be able to create a configuration since it will
+     * fall back to using default credentials.
+     */
+    @Test
+    final void defaultCredentials() {
+        final Map<String, String> props = Map.of(AWS_S3_BUCKET_NAME_CONFIG, "test-bucket");
+        final S3SinkConfig config = new S3SinkConfig(props);
+        assertThat(config.getAwsCredentials().isValid()).isFalse();
+        assertThat(config.getCustomCredentialsProvider()).isInstanceOf(DefaultAWSCredentialsProviderChain.class);
+    }
+}


### PR DESCRIPTION
This PR replaces https://github.com/Aiven-Open/s3-connector-for-apache-kafka/pull/227 which was originally implemented by @steephengeorge.

Most of the hard work was already done by @steephengeorge and this PR is a duplicate that addresses the last few code review comments left by @jeqo.

@jeqo I'd appreciate it if you could review this PR to ensure you are happy as i'd like to get this wrapped up and in.

The changes I added here were:

1. Fix the final `String.format` issue you identified.
2. Split tests for AWS credential config into their own test class
3. Add config tests for the default credentials.
4. Add tests for the new functionality that was added to `AwsCredentialProviderFactory` (the primary change in the original PR that had no tests)